### PR TITLE
fix(build): Fix broken dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | Code Quality  | [![Code Climate](https://codeclimate.com/github/obartra/ssim/badges/gpa.svg)](https://codeclimate.com/github/obartra/ssim) [![Issue Count](https://codeclimate.com/github/obartra/ssim/badges/issue_count.svg)](https://codeclimate.com/github/obartra/ssim) |
 | Versioning    | [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![npm](https://img.shields.io/npm/v/ssim.js.svg)](https://www.npmjs.com/package/ssim.js) |
 | Dependencies  | [![Known Vulnerabilities](https://snyk.io/test/github/obartra/ssim/badge.svg)](https://snyk.io/test/github/obartra/ssim) [![DavidDM](https://david-dm.org/obartra/ssim.svg)](https://david-dm.org/obartra/ssim) |
-| Environments  | ![](https://img.shields.io/badge/node-0.10-brightgreen.svg) ![](https://img.shields.io/badge/node-0.12-brightgreen.svg) ![](https://img.shields.io/badge/node-5.7.0-brightgreen.svg) ![](https://img.shields.io/badge/node-6.9-brightgreen.svg) |
+| Environments  | ![](https://img.shields.io/badge/node-0.12-brightgreen.svg) ![](https://img.shields.io/badge/node-5.7.0-brightgreen.svg) ![](https://img.shields.io/badge/node-6.9-brightgreen.svg) |
 | Documentation | [![InchCI](https://inch-ci.org/github/obartra/ssim.svg?branch=master)](https://inch-ci.org/github/obartra/ssim) [![API Doc](https://doclets.io/obartra/ssim/master.svg)](https://doclets.io/obartra/ssim/master) |
 | License       | [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://opensource.org/licenses/MIT) |
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,10 @@
 machine:
   node:
-    version: 6.9.0
+    version: 6.9.1
   environment:
-    NODE_CURRENT: 6.9.0
+    NODE_CURRENT: 6.9.1
     NODE_5: 5.7.0
     NODE_012: 0.12.9
-    NODE_010: 0.10.42
 general:
   artifacts:
     - "dist"
@@ -23,12 +22,11 @@ test:
         if [ master == $CIRCLE_BRANCH ]; then
 
           # `canvas` needs a different install depending on the node version in use.
-          nvm install $NODE_010 && rm -rf node_modules && npm i -g npm@latest && npm i --loglevel silent && npm run e2e:ivc || exit 1
-          nvm use $NODE_012 && rm -rf node_modules && npm i --loglevel silent && npm run e2e:ivc || exit 1
-          nvm use $NODE_5 && rm -rf node_modules && npm i --loglevel silent && npm run e2e:ivc || exit 1
+          nvm use $NODE_012 && rm -rf node_modules && npm i && npm run e2e:ivc || exit 1
+          nvm use $NODE_5 && rm -rf node_modules && npm i && npm run e2e:ivc || exit 1
 
           # Clean up and switch back to current node version
-          nvm use $NODE_CURRENT && rm -rf node_modules && npm i --loglevel silent
+          nvm use $NODE_CURRENT && rm -rf node_modules && npm i
           npm run e2e || exit 1
         fi
     - npm run fixme        # Make sure there are no lingering TODOs

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint": "3.8.1",
     "eslint-config-airbnb": "12.0.0",
     "eslint-config-standard": "6.2.0",
-    "eslint-plugin-import": "2.0.1",
+    "eslint-plugin-import": "1.16.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-promise": "3.3.0",
     "eslint-plugin-react": "6.4.1",
@@ -90,5 +90,8 @@
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"
     }
+  },
+  "greenkeeper": {
+    "ignore": ["eslint-plugin-import"]
   }
 }


### PR DESCRIPTION
- Disables eslint-import-plugin update from greenkeeper which breaks the build
- Removes support for node 0.10 since it's no longer officially supported
- Makes npm install on CI more verbose to assist in future debugging
