### PR TITLE
perf(processing): ➡️ Preallocate memory for arrays

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -45,7 +45,7 @@ function sum(xn) {
  * @since 0.0.1
  */
 function floor(xn) {
-	const out = [];
+	const out = new Array(xn.length);
 
 	for (let x = 0; x < xn.length; x++) {
 		out[x] = Math.floor(xn[x]);
@@ -86,7 +86,7 @@ function sum2d({ data }) {
  * @since 0.0.2
  */
 function add2dMx({ data: ref1, width, height }, { data: ref2 }) {
-	const data = [];
+	const data = new Array(ref1.length);
 
 	for (let x = 0; x < height; x++) {
 		const offset = x * width;
@@ -115,7 +115,7 @@ function add2dMx({ data: ref1, width, height }, { data: ref2 }) {
  * @since 0.0.2
  */
 function add2dScalar({ data: ref, width, height }, increase) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let x = 0; x < ref.length; x++) {
 		data[x] = ref[x] + increase;
@@ -158,7 +158,7 @@ function add2d(A, increase) {
  * @since 0.0.2
  */
 function divide2dScalar({ data: ref, width, height }, divisor) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let x = 0; x < ref.length; x++) {
 		data[x] = ref[x] / divisor;
@@ -183,7 +183,7 @@ function divide2dScalar({ data: ref, width, height }, divisor) {
  * @since 0.0.2
  */
 function divide2dMx({ data: ref1, width, height }, { data: ref2 }) {
-	const data = [];
+	const data = new Array(ref1.length);
 
 	for (let x = 0; x < ref1.length; x++) {
 		data[x] = ref1[x] / ref2[x];
@@ -226,7 +226,7 @@ function divide2d(A, divisor) {
  * @since 0.0.2
  */
 function multiply2dScalar({ data: ref, width, height }, multiplier) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let x = 0; x < ref.length; x++) {
 		data[x] = ref[x] * multiplier;
@@ -251,7 +251,7 @@ function multiply2dScalar({ data: ref, width, height }, multiplier) {
  * @since 0.0.2
  */
 function multiply2dMx({ data: ref1, width, height }, { data: ref2 }) {
-	const data = [];
+	const data = new Array(ref1.length);
 
 	for (let x = 0; x < ref1.length; x++) {
 		data[x] = ref1[x] * ref2[x];

--- a/src/matlab/filter2.js
+++ b/src/matlab/filter2.js
@@ -15,7 +15,7 @@ const { conv2 } = require('./conv2');
  * @since 0.0.2
  */
 function rotate1802d({ data: ref, width, height }) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let i = 0; i < height; i++) {
 		for (let j = 0; j < width; j++) {

--- a/src/matlab/fspecial.js
+++ b/src/matlab/fspecial.js
@@ -15,8 +15,8 @@ const { sum2d, divide2d } = require('../math');
  * @since 0.0.2
  */
 function rangeSquare2d(length) {
-	const data = [];
 	const size = length * 2 + 1;
+	const data = new Array(size ** 2);
 
 	for (let x = 0; x < size; x++) {
 		for (let y = 0; y < size; y++) {
@@ -43,7 +43,7 @@ function rangeSquare2d(length) {
  * @since 0.0.2
  */
 function gaussianFilter2d({ data: ref, width, height }, σ) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let x = 0; x < ref.length; x++) {
 		data[x] = Math.exp(-ref[x] / (2 * (σ ** 2)));

--- a/src/matlab/internal/numbers.js
+++ b/src/matlab/internal/numbers.js
@@ -11,11 +11,13 @@
  * @since 0.0.2
  */
 function numbers(height, width, num) {
-	const data = [];
+	const size = width * height;
+	const data = new Array(size);
 
-	for (let x = 0; x < width * height; x++) {
+	for (let x = 0; x < size; x++) {
 		data[x] = num;
 	}
+
 	return {
 		data,
 		width,

--- a/src/matlab/normpdf.js
+++ b/src/matlab/normpdf.js
@@ -35,7 +35,7 @@
 function normpdf({ data: ref, width, height }, µ = 0, σ = 1) {
 	// data = ((2 * pi)^(-1 / 2)) * exp(-((x - µ) / σ)^2 / 2) / σ;
 	const SQ2PI = 2.5066282746310005024157652848110;
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let i = 0; i < ref.length; i++) {
 		const z = (ref[i] - µ) / σ;

--- a/src/matlab/padarray.js
+++ b/src/matlab/padarray.js
@@ -15,7 +15,7 @@ const { mod } = require('./mod');
  * @since 0.0.2
  */
 function mirrorHorizonal({ data: ref, width, height }) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let x = 0; x < height; x++) {
 		for (let y = 0; y < width; y++) {
@@ -46,7 +46,7 @@ function mirrorHorizonal({ data: ref, width, height }) {
  * @since 0.0.2
  */
 function mirrorVertical({ data: ref, width, height }) {
-	const data = [];
+	const data = new Array(ref.length);
 
 	for (let x = 0; x < height; x++) {
 		for (let y = 0; y < width; y++) {
@@ -77,8 +77,8 @@ function mirrorVertical({ data: ref, width, height }) {
  * @since 0.0.2
  */
 function concatHorizontal(A, B) {
-	const data = [];
 	const width = A.width + B.width;
+	const data = new Array(A.height * width);
 
 	for (let x = 0; x < A.height; x++) {
 		for (let y = 0; y < A.width; y++) {
@@ -143,8 +143,8 @@ function concatVertical(A, B) {
  * @since 0.0.2
  */
 function padHorizontal(A, pad) {
-	const data = [];
 	const width = A.width + 2 * pad;
+	const data = new Array(width * A.height);
 	const mirrored = concatHorizontal(A, mirrorHorizonal(A));
 
 	for (let x = 0; x < A.height; x++) {
@@ -187,8 +187,9 @@ function padHorizontal(A, pad) {
  * @since 0.0.2
  */
 function padVertical(A, pad) {
-	const data = [];
 	const mirrored = concatVertical(A, mirrorVertical(A));
+	const height = A.height + pad * 2;
+	const data = new Array(A.width * height);
 
 	for (let x = -pad; x < A.height + pad; x++) {
 		for (let y = 0; y < A.width; y++) {
@@ -199,7 +200,7 @@ function padVertical(A, pad) {
 	return {
 		data,
 		width: A.width,
-		height: A.height + pad * 2
+		height
 	};
 }
 
@@ -252,9 +253,9 @@ function padVertical(A, pad) {
  * @since 0.0.4
  */
 function fastPadding(A, [padHeight, padWidth]) {
-	const data = [];
 	const width = A.width + padWidth * 2;
 	const height = A.height + padHeight * 2;
+	const data = new Array(width * height);
 
 	for (let x = -padHeight; x < 0; x++) {
 		// A

--- a/src/matlab/rgb2gray.js
+++ b/src/matlab/rgb2gray.js
@@ -34,7 +34,7 @@ function luma([r, g, b]) {
  * @since 0.0.2
  */
 function rgb2gray({ data: d, width, height }) {
-	const data = [];
+	const data = new Array(width * height);
 
 	for (let i = 0; i < width; i++) {
 		for (let j = 0; j < height; j++) {

--- a/src/matlab/skip2d.js
+++ b/src/matlab/skip2d.js
@@ -29,9 +29,9 @@
  * @since 0.0.2
  */
 function skip2d(A, [startRow, everyRow, endRow], [startCol, everyCol, endCol]) {
-	const data = [];
 	const width = Math.ceil((endCol - startCol) / everyCol);
 	const height = Math.ceil((endRow - startRow) / everyRow);
+	const data = new Array(width * height);
 
 	for (let i = 0; i < height; i++) {
 		for (let j = 0; j < width; j++) {

--- a/src/matlab/sub.js
+++ b/src/matlab/sub.js
@@ -14,7 +14,7 @@
  * @since 0.0.2
  */
 function sub({ data: ref, width: refWidth }, x, height, y, width) {
-	const data = [];
+	const data = new Array(width * height);
 
 	for (let i = 0; i < height; i++) {
 		for (let j = 0; j < width; j++) {

--- a/src/ssim.js
+++ b/src/ssim.js
@@ -76,7 +76,7 @@ function ssim(pixels1, pixels2, options) {
  */
 function getRange(size) {
 	const offset = Math.floor(size / 2);
-	const data = [];
+	const data = new Array(offset * 2 + 1);
 
 	for (let x = -offset; x <= offset; x++) {
 		data[x + offset] = Math.abs(x);
@@ -209,7 +209,7 @@ function imageDownsample(pixels, filter, filtert, f) {
  */
 function getDecomposedBlockFilter(length) {
 	const filterCell = Math.sqrt(1 / (length * length));
-	const data = [];
+	const data = new Array(length);
 
 	for (let i = 0; i < length; i++) {
 		data[i] = filterCell;


### PR DESCRIPTION
Preallocates memory for arrays of known size. This increases performance on all environments.
Performance gains vary. See the following links for reference:

- https://jsperf.com/0-fill-n-size-array
- https://jsperf.com/perfarrinit

Closes #39