### PR TITLE
fix(ci): Fix semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "yargs": "^6.3.0"
   },
   "devDependencies": {
+    "@bubltechnology/customizable-commit-analyzer": "^1.0.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-istanbul": "^0.11.0",


### PR DESCRIPTION
Add the @bubltechnology/customizable-commit-analyzer package, without it it was unable to release because of the config on package.json that requires it 😱