### PR TITLE
perf(transpose): Improve transpose performance

### DIFF
--- a/src/matlab/transpose.js
+++ b/src/matlab/transpose.js
@@ -1,5 +1,3 @@
-const { zeros } = require('./zeros');
-
 /**
  * Transposes a vector or a matrix
  *
@@ -17,7 +15,7 @@ const { zeros } = require('./zeros');
  * @memberOf matlab
  */
 function transpose({ data: ref, width, height }) {
-	const { data } = zeros(width, height);
+	const data = new Array(width * height);
 
 	for (let i = 0; i < height; i++) {
 		for (let j = 0; j < width; j++) {


### PR DESCRIPTION
Removes the call to `zeros` since it was unnecessary for transposing the target matrix