### PR TITLE
ci(tests): Make unit and e2e tests run in parallel

### DIFF
--- a/ci/getVersion.sh
+++ b/ci/getVersion.sh
@@ -10,3 +10,6 @@ else
   version="{ type: 'test', version: '0.0.0' }";
 fi
 echo "module.exports = $version;" > version.js
+
+# Log the output
+cat version.js

--- a/ci/node0.sh
+++ b/ci/node0.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Runs testing tasks on first CircleCI node
+#
+# Coverage related tasks are grouped together because they all depend on the output of
+# `npm run cover`.
+
+echo "Running node $CIRCLE_NODE_INDEX"
+
+npm run cover                         # Report test coverage locally
+npm run cover:check                   # Fail if coverage drops below 100%
+npm run codeclimate                   # Run tests and send coverage to code climate
+cp -R coverage/* $CIRCLE_TEST_REPORTS # Copy test coverage reports for CircleCI

--- a/ci/node1.sh
+++ b/ci/node1.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Runs remaining testing / code quality tasks on the second CircleCI node
+#
+
+echo "Running node $CIRCLE_NODE_INDEX"
+
+npm run lint                          # Ensure all code adheres to the styleguide
+npm run docs:check                    # Validate documentation using inchjs
+npm run test:perf                     # Run performance tests
+npm run test:web                      # Run cross browser web-based tests
+npm run e2e                           # Run node end to end tests

--- a/circle.yml
+++ b/circle.yml
@@ -15,26 +15,19 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++ libgnome-keyring-dev
   post:
-    - ci/getVersion.sh # Determine the version semantic-release will use, so we can include it in the build
-test:
-  pre:
+    - ci/getVersion.sh     # Determine the version semantic-release will use, so we can include it in the build
     - npm run build        # Create Node, web and test builds
+test:
   override:
-    # `canvas` needs a different install depending on the node version in use.
-    - nvm use $NODE_012 && rm -rf node_modules/canvas && npm i && npm run e2e:ivc
-    # Clean up and switch back to current node version
-    - nvm use $NODE_CURRENT && rm -rf node_modules/canvas && npm i
-
-    - npm run e2e         # Run node end to end tests
-    - npm run lint        # Ensure all code adheres to the styleguide
-    - npm run docs:check  # Validate documentation using inchjs
-    - npm run test:perf   # Run performance tests
-    - npm run test:web    # Run web-based tests
-
-    - npm run cover       # Report test coverage locally
-    - npm run cover:check # Fail if coverage drops below 100%
-    - npm run codeclimate # Run tests and send coverage to code climate
-    - cp -R coverage/* $CIRCLE_TEST_REPORTS
+    - ci/node$CIRCLE_NODE_INDEX.sh:
+        parallel: true
+    - |
+      # `canvas` package needs a different install depending on the node version in use.
+      nvm use $NODE_012 && rm -rf node_modules/canvas && npm i
+      # Run IVC dataset tests on $NODE_012
+      npm run e2e:ivc
+      # Clean up and switch back to current node version
+      nvm use $NODE_CURRENT && rm -rf node_modules/canvas && npm i
 deployment:
   publish:
     owner: obartra


### PR DESCRIPTION
unit and node e2e tests are the slowest ones to run (3-6 min). These changes should make them run in parallel to increase performance