### PR TITLE
ci(reporting): Fix Incorrect Test Coverage Report

### DIFF
--- a/ci/node0.sh
+++ b/ci/node0.sh
@@ -2,12 +2,7 @@
 #
 # Runs testing tasks on first CircleCI node
 #
-# Coverage related tasks are grouped together because they all depend on the output of
-# `npm run cover`.
 
 echo "Running node $CIRCLE_NODE_INDEX"
 
 npm run cover                         # Report test coverage locally
-npm run cover:check                   # Fail if coverage drops below 100%
-npm run codeclimate                   # Run tests and send coverage to code climate
-cp -R coverage/* $CIRCLE_TEST_REPORTS # Copy test coverage reports for CircleCI

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,9 @@ test:
   override:
     - ci/node$CIRCLE_NODE_INDEX.sh:
         parallel: true
+    - npm run cover:check                   # Fail if coverage drops below 100%
+    - npm run codeclimate                   # Run tests and send coverage to code climate
+    - cp -R coverage/* $CIRCLE_TEST_REPORTS # Copy test coverage reports for CircleCI
     - |
       # `canvas` package needs a different install depending on the node version in use.
       nvm use $NODE_012 && rm -rf node_modules/canvas && npm i


### PR DESCRIPTION
Since switching to the parallel build test coverage is not reported correctly. It's still enforced
at 100% but the reported values to codeclimate are 17%