### PR TITLE
feat(Promise): Make Promise definition independent from global

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-	"presets": ["es2015", "es2016"]
+	"presets": [
+		["es2015", { "modules": false }],
+		"es2016"
+	]
 }

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ The code is fully documented and a hosted version is available [here](https://do
 | Versioning    | [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![npm](https://img.shields.io/npm/v/ssim.js.svg)](https://www.npmjs.com/package/ssim.js) |
 | Dependencies  | [![Known Vulnerabilities](https://snyk.io/test/github/obartra/ssim/badge.svg)](https://snyk.io/test/github/obartra/ssim) [![DavidDM](https://david-dm.org/obartra/ssim.svg)](https://david-dm.org/obartra/ssim) |
 | Documentation | [![InchCI](https://inch-ci.org/github/obartra/ssim.svg?branch=master)](https://inch-ci.org/github/obartra/ssim) |
-| Environments  | ![](https://img.shields.io/badge/node-0.12-brightgreen.svg) ![](https://img.shields.io/badge/node-7.2-brightgreen.svg) [![Sauce Test Status](https://saucelabs.com/buildstatus/saucessim-master)](https://saucelabs.com/u/saucessim-master)|
+| Environments  | ![](https://img.shields.io/badge/node-0.12-brightgreen.svg) ![](https://img.shields.io/badge/node-7.3-brightgreen.svg) [![Sauce Test Status](https://saucelabs.com/buildstatus/saucessim-master)](https://saucelabs.com/u/saucessim-master)|
 
 [![Sauce Browser Matrix](https://saucelabs.com/browser-matrix/saucessim-master.svg)](https://saucelabs.com/u/saucessim-master)
 
-## 💡 Rationale
+## 💡 Credits
 
 This project is a direct port of algorithms published by [Wang, et al. 2004](/assets/ssim.pdf) on "Image Quality Assessment: From Error Visibility to Structural Similarity". The original Matlab scripts are available [here](https://ece.uwaterloo.ca/~z70wang/research/iwssim/) with their datasets. To view the steps taken to validate `ssim.js` results, check the [wiki](https://github.com/obartra/ssim/wiki/Results-Validation).

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 machine:
   node:
-    version: 7.2.1
+    version: 7.3.0
   environment:
-    NODE_CURRENT: 7.2.1
+    NODE_CURRENT: 7.3.0
     NODE_012: 0.12.9
 general:
   artifacts:

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "bmp-js": "^0.0.3",
     "canvas": "^1.6.2",
     "image-type": "^2.1.0",
+    "promiz": "^1.0.5",
     "yargs": "^6.5.0"
   },
   "devDependencies": {
@@ -75,7 +76,7 @@
     "benchmark": "^2.1.2",
     "blue-tape": "^1.0.0",
     "codeclimate-test-reporter": "^0.4.0",
-    "commitizen": "^2.9.0",
+    "commitizen": "^2.9.2",
     "condition-circle": "^1.5.0",
     "core-js": "^2.4.1",
     "cz-conventional-changelog": "^1.2.0",

--- a/spec/helpers/sampleloader.js
+++ b/spec/helpers/sampleloader.js
@@ -20,7 +20,7 @@ function toMx(txt) {
 function loadImages(samples) {
 	const promises = Object.keys(samples)
 		.map(key =>
-			readpixels(join(testPath, samples[key]))
+			readpixels(join(testPath, samples[key]), Promise)
 				.then(pixels => ({ [key]: imageDataToMx(pixels) })
 			)
 		);

--- a/spec/unit/readpixels.spec.js
+++ b/spec/unit/readpixels.spec.js
@@ -33,7 +33,7 @@ const paths = {
 const loaded = loadImages(paths);
 
 test('should read image dimensions correctly', t =>
-	readpixels('./spec/samples/lena/color.jpg')
+	readpixels('./spec/samples/lena/color.jpg', Promise)
 		.then((pixels) => {
 			t.equals(pixels.width, 512);
 			t.equals(pixels.height, 512);
@@ -41,15 +41,15 @@ test('should read image dimensions correctly', t =>
 );
 
 test('should downsize images when a limit parameter is specified', t =>
-	readpixels('./spec/samples/lena/color.jpg', 100)
+	readpixels('./spec/samples/lena/color.jpg', Promise, 100)
 		.then(pixels => t.equal(Math.min(pixels.width, pixels.height), 100))
 );
 
 test('should limit size to "limit" on the smallest axis', t =>
 	Promise.all([
-		readpixels('./spec/samples/aspectratio/8.jpg', 10) // wide
+		readpixels('./spec/samples/aspectratio/8.jpg', Promise, 10) // wide
 			.then(pixels => t.equal(pixels.height, 10)),
-		readpixels('./spec/samples/aspectratio/4.jpg', 10) // tall
+		readpixels('./spec/samples/aspectratio/4.jpg', Promise, 10) // tall
 			.then(pixels => t.equal(pixels.width, 10))
 	])
 );
@@ -57,7 +57,7 @@ test('should limit size to "limit" on the smallest axis', t =>
 test('should be able to read from a buffer', (t) => {
 	const buffer = fs.readFileSync(join(__dirname, '../samples/gradient.png'));
 
-	return readpixels(buffer)
+	return readpixels(buffer, Promise)
 		.then(imageDataToMx)
 		.then(img => t.deepEqual(img, gradientData));
 });
@@ -65,7 +65,7 @@ test('should be able to read from a buffer', (t) => {
 test('should be able to retrieve a JPG image from a URL', (t) => {
 	const url = `${baseURL}/spec/samples/gradient.jpg`;
 
-	return readpixels(url)
+	return readpixels(url, Promise)
 		.then(imageDataToMx)
 		.then(img => t.deepEqual(img, gradientData));
 });
@@ -73,7 +73,7 @@ test('should be able to retrieve a JPG image from a URL', (t) => {
 test('should be able to retrieve a PNG image from a URL', (t) => {
 	const url = `${baseURL}/spec/samples/gradient.png`;
 
-	return readpixels(url)
+	return readpixels(url, Promise)
 		.then(imageDataToMx)
 		.then(img => t.deepEqual(img, gradientData));
 });
@@ -81,7 +81,7 @@ test('should be able to retrieve a PNG image from a URL', (t) => {
 test('should be able to retrieve a GIF image from a URL', (t) => {
 	const url = `${baseURL}/spec/samples/gradient.gif`;
 
-	return readpixels(url)
+	return readpixels(url, Promise)
 		.then(imageDataToMx)
 		.then(img => t.deepEqual(img, gradientData));
 });
@@ -89,13 +89,13 @@ test('should be able to retrieve a GIF image from a URL', (t) => {
 test('should be able to retrieve a BMP image from a URL', (t) => {
 	const url = `${baseURL}/spec/samples/gradient.bmp`;
 
-	return readpixels(url)
+	return readpixels(url, Promise)
 		.then(imageDataToMx)
 		.then(img => t.deepEqual(img, gradientData));
 });
 
 test('should throw if trying to retrieve an invalid URL', t =>
-	readpixels('fakeurl.com/image1.png')
+	readpixels('fakeurl.com/image1.png', Promise)
 		.then(() => t.fail('Should have thrown an error'))
 		.catch(t.ok)
 );

--- a/spec/web/index.html
+++ b/spec/web/index.html
@@ -13,6 +13,7 @@
 		<p id="test-results">In progress...</p>
 		<div id="images"></div>
 		<div id="tests"></div>
+		<script src="../../node_modules/promiz/promiz.min.js"></script>
 		<script src="../../dist/ssim.web.js"></script>
 		<script src="https://wzrd.in/standalone/tape@4.6.3"></script>
 		<script src="https://wzrd.in/standalone/tape-dom@0.0.12"></script>

--- a/src/matlab/rgb2gray.js
+++ b/src/matlab/rgb2gray.js
@@ -10,13 +10,15 @@
  * SSIM. Based on some sample data changes were of the order of 10^-3.
  *
  * @method luma
- * @param {Number[]} subpixels - The different pixels to use in the following order: r, g, b
+ * @param {Number} r - The red pixel value
+ * @param {Number} g - The green pixel value
+ * @param {Number} b - The blue pixel value
  * @returns {Number} lumaValue - The value of the luminance for the [r,g,b] pixel
  * @private
  * @memberOf matlab
  * @since 0.0.2
  */
-function luma([r, g, b]) {
+function luma(r, g, b) {
 	return Math.round(0.29894 * r + 0.58704 * g + 0.11402 * b);
 }
 
@@ -41,7 +43,7 @@ function rgb2gray({ data: d, width, height }) {
 			const grayIndex = i + j * width;
 			const imgIndex = grayIndex * 4;
 
-			data[grayIndex] = luma([d[imgIndex], d[imgIndex + 1], d[imgIndex + 2], d[imgIndex + 3]]);
+			data[grayIndex] = luma(d[imgIndex], d[imgIndex + 1], d[imgIndex + 2], d[imgIndex + 3]);
 		}
 	}
 	return {

--- a/src/readpixels.js
+++ b/src/readpixels.js
@@ -38,9 +38,7 @@ function parse(data, limit) {
 		imageData = ctx.getImageData(0, 0, width, height);
 	}
 
-	return new Promise((resolve) => {
-		resolve(imageData);
-	});
+	return imageData;
 }
 
 /**
@@ -48,13 +46,14 @@ function parse(data, limit) {
  *
  * @method loadUrl
  * @param {string} url - url to load image data from
+ * @param {function} P - The Promise definition, must be a valid Promises/A+ implementation
  * @returns {Promise} promise - A promise that resolves with the image 3D matrix
  * @private
  * @memberOf readpixels
  * @since 0.0.1
  */
-function loadUrl(url) {
-	return new Promise((resolve, reject) => {
+function loadUrl(url, P) {
+	return new P((resolve, reject) => {
 		http
 			.get(url)
 			.on('response', (res) => {
@@ -72,13 +71,14 @@ function loadUrl(url) {
  *
  * @method loadFs
  * @param {string} path - File path to load image data from
+ * @param {function} P - The Promise definition, must be a valid Promises/A+ implementation
  * @returns {Promise} promise - A promise that resolves with the image 3D matrix
  * @private
  * @memberOf readpixels
  * @since 0.0.1
  */
-function loadFs(path) {
-	return new Promise((resolve, reject) => {
+function loadFs(path, P) {
+	return new P((resolve, reject) => {
 		fs.readFile(path, (err, data) => {
 			if (err) {
 				reject(err);
@@ -95,6 +95,7 @@ function loadFs(path) {
  *
  * @method readpixels
  * @param {string|Buffer} url - A url, file path or buffer to use to load the image data
+ * @param {function} P - The Promise definition, must be a valid Promises/A+ implementation
  * @param {number} [limit=0] - A limit that, if set and both dimensions (width / height) surpass it,
  * will downsize the image to that size on the smallest dimension.
  * @returns {Promise} promise - A promise that resolves with the image 3D matrix
@@ -102,15 +103,15 @@ function loadFs(path) {
  * @memberOf readpixels
  * @since 0.0.1
  */
-function readpixels(url, limit = 0) {
+function readpixels(url, P, limit = 0) {
 	let bufferPromise;
 
 	if (Buffer.isBuffer(url)) {
-		bufferPromise = Promise.resolve(url);
+		bufferPromise = P.resolve(url);
 	} else if (url.indexOf('http://') === 0 || url.indexOf('https://') === 0) {
-		bufferPromise = loadUrl(url);
+		bufferPromise = loadUrl(url, P);
 	} else {
-		bufferPromise = loadFs(url);
+		bufferPromise = loadFs(url, P);
 	}
 	return bufferPromise
 		.then(bufferData => parse(bufferData, limit));

--- a/src/readpixels.web.js
+++ b/src/readpixels.web.js
@@ -6,18 +6,19 @@ const { getLimitDimensions } = require('./util');
  *
  * @method readpixels
  * @param {string} url - The url to use to load the image data
+ * @param {function} P - The Promise definition, must be a valid Promises/A+ implementation
  * @param {number} [limit=0] - A limit that, if set and both dimensions (width / height) surpass it,
  * will downsize the image to that size on the smallest dimension.
  * @returns {Promise} promise - A promise that resolves with the image 3D matrix
  * @public
  * @memberOf readpixelsWeb
  */
-function readpixels(url, limit = 0) {
+function readpixels(url, P, limit = 0) {
 	const img = new Image();
 	const canvas = document.createElement('canvas');
 	const ctx = canvas.getContext('2d');
 
-	return new Promise((resolve, reject) => {
+	return new P((resolve, reject) => {
 		img.onload = () => {
 			const { width, height } = getLimitDimensions(img.width, img.height, limit);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ const webpack = require('webpack');
 
 module.exports = {
 	entry: [
-		'core-js/es6/promise',
 		'core-js/modules/es6.object.keys',
 		'core-js/modules/es6.object.assign',
 		'./index.js'


### PR DESCRIPTION
- Prior implementation added a global polyfill when promises were not available
- Replaced with a < 1kb polyfill
  - corejs promise is 50kb! and forces node deopt
- With these changes, we still default to global Promises and fallback to a polyfill
  but they can be redifined (by replacing ssim.Promise)
- Also removed some needless destructuring