### PR TITLE
fix: remove DOM as lib dependency for typescript

### DIFF
--- a/spec/helpers/util.ts
+++ b/spec/helpers/util.ts
@@ -1,4 +1,4 @@
-import { Matrix } from '../../src/types'
+import { Matrix, ImageData } from '../../src/types'
 
 type AnyMatrix =
   | Matrix

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { originalSsim } from './originalSsim'
 import { bezkrovnySsim } from './bezkrovnySsim'
 import { downsample } from './downsample'
 import { defaults } from './defaults'
-import { Options, Images, Matrices, Matrix, MSSIMMatrix } from './types'
+import { Options, Images, Matrices, Matrix, MSSIMMatrix, ImageData } from './types'
 import { weberSsim } from './weberSsim'
 
 export { Options, Matrix }

--- a/src/matlab/rgb2gray.ts
+++ b/src/matlab/rgb2gray.ts
@@ -1,4 +1,4 @@
-import { Matrix } from '../types'
+import { Matrix, ImageData } from '../types'
 
 /**
  * Converts an imageData object of { width, height, data } into a 2d matrix [row, column]

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,12 @@ export type Matrix = {
   data: number[]
 }
 
+export type ImageData = {
+  readonly data: Uint8ClampedArray;
+  readonly height: number;
+  readonly width: number;
+}
+
 export type ImageMatrix =
   | Matrix
   | ImageData

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
-      "ESNext",
-      "DOM"
+      "ESNext"
     ] /* Specify library files to be included in the compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
This PR will remove the `lib.dom.d.ts` dependency. This is necesary in order to use this libabry in a node project that uses typescript. See #282 for more information.

I have just made a copy of `ImageData`, I saw that all properties (width, height and data) was used but I also saw that `ImageData` and `Matrix` are identical except for the type on `data`. `ImageData.data` is a `Uint8ClampedArray` while `Matrix.data` is a `number[]`. I guess there is a reason why they both coexists. 


fix #282


